### PR TITLE
Update conver2mp3.txt

### DIFF
--- a/conver2mp3.txt
+++ b/conver2mp3.txt
@@ -1,1 +1,6 @@
-for a in ~/Music/*.opus; do  ffmpeg -i "$a" -qscale:a 0 "${a[@]/%opus/mp3}"; done
+#!/bin/bash
+
+
+for a in ~/Music/*.opus;
+do  ffmpeg -hide_banner -i "$a" -qscale:a 0 "${a[@]/%opus/mp3}";
+done


### PR DESCRIPTION
- add shebang line;
- pass the "-hide_banner" flag to the ffmpeg command to suppress verbosity;
---
Hi, 

wie gesagt, habe die Shebang-Zeile hinzugefügt. 

Außerdem dachte ich, es wäre eine gute Idee, dem ffmpeg-Befehl das `-hide_banner`-Argument zu übergeben, dadurch wird dieser ellenlange Text unterdrückt, der beim Konvertieren immer das halbe Terminal zu-"spämt" :-D (die ganzen Bibliotheken, Copyright-Infos usw). 

Gruß
